### PR TITLE
日本語変数名を定義できるようにした

### DIFF
--- a/src/main/scala/com/github/nihongo/Parser.scala
+++ b/src/main/scala/com/github/nihongo/Parser.scala
@@ -448,7 +448,9 @@ class Parser extends Processor[String, Program, InteractiveSession] {
         case id ~ ids => ids.foldLeft(id.name) { case (a, d ~ e) => a + d + e.name }
       }
 
-      lazy val component: Parser[String] = """[A-Za-z_][a-zA-Z0-9_]*""".r
+      lazy val component: Parser[String] = (
+        """[A-Za-z_][A-Za-z_0-9]*|「([A-Za-z_]|\p{InCjkUnifiedIdeographs}|\p{InHiragana}|\p{InKatakana})(\w|\p{InCjkUnifiedIdeographs}|\p{InHiragana}|\p{InKatakana})*」""".r
+      )
 
       lazy val placeholder: Parser[Placeholder] = ((%% ~ UNDERSCORE) ^^ { case location ~ _ => Placeholder(location) }) << SPACING_WITHOUT_LF
 

--- a/src/test/scala/com/github/nihongo/JapaneseVariableSpec.scala
+++ b/src/test/scala/com/github/nihongo/JapaneseVariableSpec.scala
@@ -1,0 +1,82 @@
+package com.github.nihongo
+
+/**
+  * Created by Mizushima on 2022/08/12.
+  */
+class JapaneseVariableSpec extends SpecHelper {
+  describe("漢字変数名") {
+    it("変数「今年」が定義できること") {
+      assertResult(
+        E(
+          """
+            |変数「今年」は2022
+            |「今年」
+          """.stripMargin))(BoxedInt(2022))
+    }
+    it("変数「国」が定義できること") {
+      assertResult(
+        E(
+          """
+            |変数「国」は"日本"
+            |「国」
+          """.stripMargin))(ObjectValue("日本")
+      )
+    }
+  }
+  describe("ひらがな変数名") {
+    it("変数「あなた」が定義できること") {
+      assertResult(
+        E(
+          """
+            |変数「あなた」は"You"
+            |「あなた」
+          """.stripMargin))(ObjectValue("You"))
+    }
+    it("変数「わたし」が定義できること") {
+      assertResult(
+        E(
+          """
+            |変数「わたし」は"I"
+            |「わたし」
+          """.stripMargin))(ObjectValue("I")
+      )
+    }
+  }
+  describe("カタカナ変数名") {
+    it("変数「アメリカ」が定義できること") {
+      assertResult(
+        E(
+          """
+            |変数「アメリカ」は"America"
+            |「アメリカ」
+          """.stripMargin))(ObjectValue("America"))
+    }
+    it("変数「アルバイト」が定義できること") {
+      assertResult(
+        E(
+          """
+            |変数「アルバイト」は"part-time job"
+            |「アルバイト」
+          """.stripMargin))(ObjectValue("part-time job")
+      )
+    }
+  }
+  describe("漢字かな混じり変数名") {
+    it("変数「日本の首都」が定義できること") {
+      assertResult(
+        E(
+          """
+            |変数「日本の首都」は"東京"
+            |「日本の首都」
+          """.stripMargin))(ObjectValue("東京"))
+    }
+    it("変数「職場までの距離」が定義できること") {
+      assertResult(
+        E(
+          """
+            |変数「職場までの距離」は400
+            |「職場までの距離」
+          """.stripMargin))(BoxedInt(400))
+    }
+  }
+}


### PR DESCRIPTION
- 例：変数「円周率」は3.14
- つまり「」でくくるという解決策
  - アドホックだけど仕方がない