### PR TITLE
辞書リテラルの記法を変更

### DIFF
--- a/src/main/scala/com/github/nuko/NukoParser.scala
+++ b/src/main/scala/com/github/nuko/NukoParser.scala
@@ -116,6 +116,7 @@ class NukoParser extends Processor[String, Program, InteractiveSession] {
       val LTE: Parser[String] = kwToken("<=")
       val GTE: Parser[String] = kwToken(">=")
       val 辞書開始: Parser[String] = kwToken("辞書[")
+      val 辞書区切り: Parser[String] = kwToken("→") | kwToken("->")
       val リスト開始: Parser[String] = kwToken("リスト[")
       val SET_OPEN: Parser[String] = kwToken("%(")
       val UNDERSCORE: Parser[String] = kwToken("_")
@@ -425,7 +426,7 @@ class NukoParser extends Processor[String, Program, InteractiveSession] {
         case location ~ contents => SetLiteral(location, contents)
       })
 
-      lazy val 辞書リテラル: Parser[Ast.Node] = rule(%% ~ (CL(辞書開始) >> commit((CL(expression ~ COLON ~ expression).repeat0By(SEPARATOR) << SEPARATOR.?) << 閉じブラケット)) ^^ {
+      lazy val 辞書リテラル: Parser[Ast.Node] = rule(%% ~ (CL(辞書開始) >> commit((CL(expression ~ 辞書区切り ~ expression).repeat0By(SEPARATOR) << SEPARATOR.?) << 閉じブラケット)) ^^ {
         case location ~ contents => MapLiteral(location, contents.map { case k ~ colon ~ v => (k, v) })
       })
 

--- a/src/test/scala/com/github/nuko/DictionarySpec.scala
+++ b/src/test/scala/com/github/nuko/DictionarySpec.scala
@@ -4,13 +4,13 @@ class DictionarySpec extends SpecHelper {
   describe("containsKey") {
     val expectations: List[(String, Value)] = List(
       """
-        |辞書["name": "Kota Mizushima" "age": "33"] Map#containsKey "name"
+        |辞書["名前" -> "Kota Mizushima" "年齢" -> "33"] Map#containsKey "名前"
       """.stripMargin -> BoxedBoolean(true),
       """
-        |辞書["name": "Kota Mizushima" "age": "33"] Map#containsKey "age"
+        |辞書["名前" -> "Kota Mizushima" "年齢" -> "33"] Map#containsKey "年齢"
       """.stripMargin -> BoxedBoolean(true),
       """
-        |辞書["name": "Kota Mizushima" "age": "33"] Map#containsKey "hoge"
+        |辞書["名前" -> "Kota Mizushima" "年齢" -> "33"] Map#containsKey "hoge"
       """.stripMargin -> BoxedBoolean(false)
     )
 
@@ -21,16 +21,16 @@ class DictionarySpec extends SpecHelper {
     }
   }
 
-  describe("containsValue") {
+  describe("含む") {
     val expectations: List[(String, Value)] = List(
       """
-        |辞書["name": "Kota Mizushima" "age": "33"] Map#containsValue "33"
+        |辞書["名前" -> "Kota Mizushima" "年齢" -> "33"] Map#containsValue "33"
       """.stripMargin -> BoxedBoolean(true),
       """
-        |辞書["name": "Kota Mizushima" "age": "33"] Map#containsValue "Kota Mizushima"
+        |辞書["名前" -> "Kota Mizushima" "年齢" -> "33"] Map#containsValue "Kota Mizushima"
       """.stripMargin -> BoxedBoolean(true),
       """
-        |辞書["name": "Kota Mizushima" "age": "33"] Map#containsValue "hoge"
+        |辞書["名前" -> "Kota Mizushima" "年齢" -> "33"] Map#containsValue "hoge"
       """.stripMargin -> BoxedBoolean(false)
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
@@ -40,16 +40,16 @@ class DictionarySpec extends SpecHelper {
     }
   }
 
-  describe("get") {
+  describe("取得") {
     val expectations: List[(String, Value)] = List(
       """
-        |辞書["name": "Kota Mizushima" "age": "33"] Map#get "age"
-      """.stripMargin -> ObjectValue("33"),
+        |辞書["名前" -> "水島宏太" "年齢" -> "40"] Map#get "年齢"
+      """.stripMargin -> ObjectValue("40"),
       """
-        |辞書["name": "Kota Mizushima" "age": "33"] Map#get "name"
-      """.stripMargin -> ObjectValue("Kota Mizushima"),
+        |辞書["名前" -> "水島宏太" "年齢" -> "40"] Map#get "名前"
+      """.stripMargin -> ObjectValue("水島宏太"),
       """
-        |辞書["name": "Kota Mizushima" "age": "33"] Map#get "hoge"
+        |辞書["名前" -> "水島宏太" "年齢" -> "33"] Map#get "性別"
       """.stripMargin -> ObjectValue(null)
     )
     expectations.zipWithIndex.foreach{ case ((in, expected), i) =>
@@ -67,7 +67,7 @@ class DictionarySpec extends SpecHelper {
     )
     expect("non empty map should not be isEmpty")(
       """
-        |Map#isEmpty(辞書["x": 1 "y": 2])
+        |Map#isEmpty(辞書["x" -> 1 "y" -> 2])
       """.stripMargin -> BoxedBoolean(false)
     )
   }

--- a/src/test/scala/com/github/nuko/LiteralSpec.scala
+++ b/src/test/scala/com/github/nuko/LiteralSpec.scala
@@ -106,11 +106,11 @@ class LiteralSpec extends SpecHelper {
   describe("map literal") {
     val expectations = List[(String, Value)](
       "辞書[]" -> ObjectValue(mapOf[String, String]()),
-      "辞書[1 : 2]" -> ObjectValue(mapOf(BigInt(1) -> BigInt(2))),
-      """辞書["a":"b"]""" -> ObjectValue(mapOf("a" -> "b")),
-      """辞書["a":"b" "c":"d"]""" -> ObjectValue(mapOf("a" -> "b", "c" -> "d")),
-    """辞書["a":"b"
-      | "c":"d"]""".stripMargin -> ObjectValue(mapOf("a" -> "b", "c" -> "d"))
+      "辞書[1 -> 2]" -> ObjectValue(mapOf(BigInt(1) -> BigInt(2))),
+      """辞書["a" -> "b"]""" -> ObjectValue(mapOf("a" -> "b")),
+      """辞書["a" -> "b" "c" -> "d"]""" -> ObjectValue(mapOf("a" -> "b", "c" -> "d")),
+    """辞書["a" -> "b"
+         | "c" -> "d"]""".stripMargin -> ObjectValue(mapOf("a" -> "b", "c" -> "d"))
     )
     expectations.zipWithIndex.foreach { case ((in, expected), i) =>
       it(s"${in} evaluates to ${expected}") {

--- a/test-programs/dictionary-literal.ni
+++ b/test-programs/dictionary-literal.ni
@@ -1,12 +1,10 @@
-変数 dict1 は 辞書["A": 1, "B": 2]
+変数 dict1 は 辞書["A" -> 1, "B" -> 2]
 assertResult(1)(dict1 Map#get "A")
 assertResult(2)(dict1 Map#get "B")
 assertResult(null)(dict1 Map#get "C")
 
 変数 dict2は 辞書[
-    "A" : 1
-    "B" : 2
+    "A" -> 1
+    "B" -> 2
 ]
 assertResult(dict1)(dict2)
-
-変数 dict3 は 辞書["A": 1, "B": 2]


### PR DESCRIPTION
前：辞書["k":"v"]
後：辞書["k"->"v"] または 辞書["k"→"v"]